### PR TITLE
docs: add Prisma Client generation command to setup instructions

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -35,6 +35,7 @@ cd threads-analytics
 pnpm install
 cp .env.example .env.local # または手動で .env.local を作成
 npx prisma migrate dev --name init
+npx prisma generate
 pnpm dev
 ```
 
@@ -96,6 +97,7 @@ SYNC_SCHEDULER_ENABLED=false              # 常時稼働の環境でのみ true 
 
 ```bash
 npx prisma migrate dev --name init
+npx prisma generate
 ```
 
 ### 4. 開発サーバーの起動
@@ -121,6 +123,7 @@ pnpm build        # 本番用ビルド
 pnpm start        # マイグレーションを実行して本番サーバーを起動
 npx prisma studio # データベース GUI を開く
 npx prisma migrate dev --name <name>  # 新しいマイグレーションを作成
+npx prisma generate # Prisma Client を再生成
 ```
 
 ## Threads アクセストークンの取得

--- a/README-zh.md
+++ b/README-zh.md
@@ -35,6 +35,7 @@ cd threads-analytics
 pnpm install
 cp .env.example .env.local # 或手動建立 .env.local
 npx prisma migrate dev --name init
+npx prisma generate
 pnpm dev
 ```
 
@@ -96,6 +97,7 @@ SYNC_SCHEDULER_ENABLED=false              # 只有長時間運行的部署環境
 
 ```bash
 npx prisma migrate dev --name init
+npx prisma generate
 ```
 
 ### 4. 啟動開發伺服器
@@ -121,6 +123,7 @@ pnpm build        # 建置正式版
 pnpm start        # 執行資料庫 migration 並啟動正式伺服器
 npx prisma studio # 開啟資料庫 GUI
 npx prisma migrate dev --name <名稱>  # 建立新的 migration
+npx prisma generate # 重新產生 Prisma Client
 ```
 
 ## 取得 Threads Access Token

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ cd threads-analytics
 pnpm install
 cp .env.example .env.local # or create .env.local manually
 npx prisma migrate dev --name init
+npx prisma generate
 pnpm dev
 ```
 
@@ -96,6 +97,7 @@ SYNC_SCHEDULER_ENABLED=false              # set true only on long-running deploy
 
 ```bash
 npx prisma migrate dev --name init
+npx prisma generate
 ```
 
 ### 4. Start the dev server
@@ -121,6 +123,7 @@ pnpm build        # Build for production
 pnpm start        # Run migrations and start production server
 npx prisma studio # Open database GUI
 npx prisma migrate dev --name <name>  # Create a new migration
+npx prisma generate # Regenerate the Prisma Client
 ```
 
 ## Getting Your Threads Access Token


### PR DESCRIPTION
This pull request updates the setup instructions in the English, Japanese, and Chinese README files to include `npx prisma generate` after the migration step. This ensures the Prisma Client is generated after setting up the database, preventing compilation errors caused by missing Prisma Client modules.